### PR TITLE
Use correct PAM status code when config file for user doesn't exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"strings"
 	"time"
 	"unsafe"
@@ -175,7 +176,13 @@ func goAuthenticate(handle *C.pam_handle_t, flags C.int, argv []string) C.int {
 	}
 	addrs, err := readUserConfig(username)
 	if err != nil {
-		return C.PAM_USER_UNKNOWN
+		logError(err)
+		switch err.(type) {
+		case user.UnknownUserError:
+			return C.PAM_USER_UNKNOWN
+		default:
+			return C.PAM_AUTHINFO_UNAVAIL
+		}
 	}
 
 	if findDevice(addrs[0]) {


### PR DESCRIPTION
I was irritated because of the error message (config file didn't exist):

```
juergen@lemmy:~ → pamtester -v system-auth-beacon juergen authenticate
pamtester: invoking pam_start(system-auth-beacon, juergen, ...)
pamtester: performing operation - authenticate
DEBU[0000] argv: [debug]                                
DEBU[0000] Parsing MAC addresses from /home/juergen/.authorized_beacons 
pamtester: User not known to the underlying authentication module
```
Using this commit:
```
juergen@lemmy:~ → pamtester -v system-auth-beacon juergen authenticate
pamtester: invoking pam_start(system-auth-beacon, juergen, ...)
pamtester: performing operation - authenticate
DEBU[0000] argv: [debug]                                
DEBU[0000] Parsing MAC addresses from /home/juergen/.authorized_beacons 
ERRO[0000] open /home/juergen/.authorized_beacons: no such file or directory 
pamtester: Authentication service cannot retrieve authentication info
```